### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ clean-core
 > clean-core - [php](http://php.net) library
 
 ## Install
-
+```sh
+composer require g4/clean-core
+```
 ## Usage
 
 ## Development


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
